### PR TITLE
link plugin executables statically

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,12 @@ RUN /script/test_install_cni_plugins.sh
 
 FROM golang:1.11 as build
 
-ENV BRANCH_OR_TAG=v0.8.3
+ENV BRANCH_OR_TAG=v1.1.1
 
 WORKDIR /go/src/app
 RUN git clone --branch ${BRANCH_OR_TAG} \
       https://github.com/containernetworking/plugins.git . && \
-    ./build_linux.sh
+    GO111MODULE=on
 
 FROM busybox
 COPY --from=build /go/src/app/bin /opt/cni/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV BRANCH_OR_TAG=v1.1.1
 WORKDIR /go/src/app
 RUN git clone --branch ${BRANCH_OR_TAG} \
       https://github.com/containernetworking/plugins.git . && \
-    GO111MODULE=on
+    GO111MODULE=on ./build_linux.sh -ldflags="-extldflags=-static" -tags "osusergo netgo"
 
 FROM busybox
 COPY --from=build /go/src/app/bin /opt/cni/bin


### PR DESCRIPTION
Previously the plugin executables installed by this script had dependencies on shared libraries (`libpthread.so.0` and `libc.so.6`). These libraries might not be installed on the kubelet host system, or might be at a different version. If that's the case, the kubelet service won't be able to execute these plugins.

Linking the executables statically is a more portable solution.

Merge #1 first because conflicts suck.